### PR TITLE
[BUGFIX] Event type incorrect when loading projection streams

### DIFF
--- a/src/EventStore/StreamFeed/Entry.php
+++ b/src/EventStore/StreamFeed/Entry.php
@@ -35,7 +35,7 @@ final class Entry
 
     public function getType()
     {
-        return $this->json['summary'];
+        return (isset($this->json['eventType'])) ? $this->json['eventType'] : $this->json['summary'];
     }
 
     /**

--- a/tests/EventStore/Tests/StreamFeed/EntryTest.php
+++ b/tests/EventStore/Tests/StreamFeed/EntryTest.php
@@ -11,4 +11,17 @@ class EntryTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Bar', $entry->getType());
     }
+
+    /**
+     * @test
+     */
+    public function theEventTypeForEntriesOfAnProjectionStreamFeedIsCorrect()
+    {
+        $json = file_get_contents(__DIR__ . '/Fixtures/RichEventStoreCeEntryResponse.json');
+        $entryData = json_decode($json, TRUE);
+
+        $entry = new Entry($entryData);
+
+        $this->assertEquals('ThingsHappenedEvent', $entry->getType());
+    }
 }

--- a/tests/EventStore/Tests/StreamFeed/Fixtures/RichEventStoreCeEntryResponse.json
+++ b/tests/EventStore/Tests/StreamFeed/Fixtures/RichEventStoreCeEntryResponse.json
@@ -1,0 +1,26 @@
+{
+  "eventId": "fbf4a1a1-b4a3-4dfe-b62f-ec52c34e16e4",
+  "eventType": "ThingsHappenedEvent",
+  "eventNumber": 0,
+  "streamId": "AggregateType-e08bf2bc-af5d-8750-f4a9-ca7bcc7137d4",
+  "isJson": true,
+  "isMetaData": false,
+  "isLinkMetaData": false,
+  "positionEventNumber": 0,
+  "positionStreamId": "$ce-AggregateType",
+  "title": "0@AggregateType-e08bf2bc-af5d-8750-f4a9-ca7bcc7137d4",
+  "id": "http:\/\/127.0.0.1:2113\/streams\/AggregateType-e08bf2bc-af5d-8750-f4a9-ca7bcc7137d4\/0",
+  "updated": "2015-04-08T06:00:06.863695Z",
+  "author": {"name": "EventStore"},
+  "summary": "$>",
+  "links": [
+    {
+      "uri": "http:\/\/127.0.0.1:2113\/streams\/AggregateType-e08bf2bc-af5d-8750-f4a9-ca7bcc7137d4\/0",
+      "relation": "edit"
+    },
+    {
+      "uri": "http:\/\/127.0.0.1:2113\/streams\/AggregateType-e08bf2bc-af5d-8750-f4a9-ca7bcc7137d4\/0",
+      "relation": "alternate"
+    }
+  ]
+}


### PR DESCRIPTION
This is due to the fact, that the summary field in the response
is no longer the event type.

This test uses a fixture which is returned from an event store
v3.0.3.

Resolves #13