### PR TITLE
[TASK] Streamline code formatting

### DIFF
--- a/src/EventStore/EventStore.php
+++ b/src/EventStore/EventStore.php
@@ -59,12 +59,12 @@ final class EventStore implements EventStoreInterface
     /**
      * Delete a stream
      *
-     * @param string         $stream_name Name of the stream
-     * @param StreamDeletion $mode        Deletion mode (soft or hard)
+     * @param string         $streamName Name of the stream
+     * @param StreamDeletion $mode       Deletion mode (soft or hard)
      */
-    public function deleteStream($stream_name, StreamDeletion $mode)
+    public function deleteStream($streamName, StreamDeletion $mode)
     {
-        $request = $this->httpClient->createRequest('DELETE', $this->getStreamUrl($stream_name));
+        $request = $this->httpClient->createRequest('DELETE', $this->getStreamUrl($streamName));
 
         if ($mode == StreamDeletion::HARD) {
             $request->addHeader('ES-HardDelete', 'true');
@@ -86,47 +86,47 @@ final class EventStore implements EventStoreInterface
     /**
      * Navigate stream feed through link relations
      *
-     * @param  StreamFeed      $stream_feed The stream feed to navigate through
-     * @param  LinkRelation    $relation    The "direction" expressed as link relation
+     * @param  StreamFeed      $streamFeed The stream feed to navigate through
+     * @param  LinkRelation    $relation   The "direction" expressed as link relation
      * @return null|StreamFeed
      */
-    public function navigateStreamFeed(StreamFeed $stream_feed, LinkRelation $relation)
+    public function navigateStreamFeed(StreamFeed $streamFeed, LinkRelation $relation)
     {
-        $url = $stream_feed->getLinkUrl($relation);
+        $url = $streamFeed->getLinkUrl($relation);
 
         if (empty($url)) {
             return null;
         }
 
-        return $this->readStreamFeed($url, $stream_feed->getEntryEmbedMode());
+        return $this->readStreamFeed($url, $streamFeed->getEntryEmbedMode());
     }
 
     /**
      * Open a stream feed for read and navigation
      *
-     * @param  string         $stream_name The stream name
-     * @param  EntryEmbedMode $embed_mode  The event entries embed mode (none, rich or body)
+     * @param  string         $streamName The stream name
+     * @param  EntryEmbedMode $embedMode  The event entries embed mode (none, rich or body)
      * @return StreamFeed
      */
-    public function openStreamFeed($stream_name, EntryEmbedMode $embed_mode = null)
+    public function openStreamFeed($streamName, EntryEmbedMode $embedMode = null)
     {
-        $url = $this->getStreamUrl($stream_name);
+        $url = $this->getStreamUrl($streamName);
 
-        return $this->readStreamFeed($url, $embed_mode);
+        return $this->readStreamFeed($url, $embedMode);
     }
 
     /**
      * Read a single event
      *
-     * @param  string $event_url The url of the event
+     * @param  string $eventUrl The url of the event
      * @return Event
      */
-    public function readEvent($event_url)
+    public function readEvent($eventUrl)
     {
-        $request = $this->getJsonRequest($event_url);
+        $request = $this->getJsonRequest($eventUrl);
         $this->sendRequest($request);
 
-        $this->ensureStatusCodeIsGood($event_url);
+        $this->ensureStatusCodeIsGood($eventUrl);
 
         $jsonResponse = $this->lastResponse->json();
 
@@ -136,12 +136,12 @@ final class EventStore implements EventStoreInterface
     /**
      * Write one or more events to a stream
      *
-     * @param  string                                  $stream_name     The stream name
+     * @param  string                                  $streamName      The stream name
      * @param  WritableToStream                        $events          Single event or a collection of events
      * @param  int                                     $expectedVersion The expected version of the stream
      * @throws Exception\WrongExpectedVersionException
      */
-    public function writeToStream($stream_name, WritableToStream $events, $expectedVersion = ExpectedVersion::ANY)
+    public function writeToStream($streamName, WritableToStream $events, $expectedVersion = ExpectedVersion::ANY)
     {
         if ($events instanceof WritableEvent) {
             $events = new WritableEventCollection([$events]);
@@ -151,7 +151,7 @@ final class EventStore implements EventStoreInterface
             ->httpClient
             ->createRequest(
                 'POST',
-                $this->getStreamUrl($stream_name),
+                $this->getStreamUrl($streamName),
                 [
                     'json' => $events->toStreamData(),
                 ]
@@ -184,38 +184,42 @@ final class EventStore implements EventStoreInterface
     }
 
     /**
-     * @param  string $stream_name
+     * @param  string $streamName
      * @return string
      */
-    private function getStreamUrl($stream_name)
+    private function getStreamUrl($streamName)
     {
-        return sprintf('%s/streams/%s', $this->url, $stream_name);
+        return sprintf('%s/streams/%s', $this->url, $streamName);
     }
 
     /**
-     * @param  string                            $stream_url
-     * @param  EntryEmbedMode                    $embed_mode
+     * @param  string                            $streamUrl
+     * @param  EntryEmbedMode                    $embedMode
      * @return StreamFeed
      * @throws Exception\StreamDeletedException
      * @throws Exception\StreamNotFoundException
      */
-    private function readStreamFeed($stream_url, EntryEmbedMode $embed_mode = null)
+    private function readStreamFeed($streamUrl, EntryEmbedMode $embedMode = null)
     {
-        $request = $this->getJsonRequest($stream_url);
+        $request = $this->getJsonRequest($streamUrl);
 
-        if ($embed_mode != null && $embed_mode != EntryEmbedMode::NONE()) {
-            $request->getQuery()->add('embed', $embed_mode->toNative());
+        if ($embedMode != null && $embedMode != EntryEmbedMode::NONE()) {
+            $request->getQuery()->add('embed', $embedMode->toNative());
         }
 
         $this->sendRequest($request);
 
-        $this->ensureStatusCodeIsGood($stream_url);
+        $this->ensureStatusCodeIsGood($streamUrl);
 
         $jsonResponse = $this->lastResponse->json();
 
-        return new StreamFeed($jsonResponse, $embed_mode);
+        return new StreamFeed($jsonResponse, $embedMode);
     }
 
+    /**
+     * @param  string                                       $uri
+     * @return \GuzzleHttp\Message\Request|RequestInterface
+     */
     private function getJsonRequest($uri)
     {
         return $this
@@ -245,46 +249,46 @@ final class EventStore implements EventStoreInterface
     }
 
     /**
-     * @param $stream_url
+     * @param  string                            $streamUrl
      * @throws Exception\StreamDeletedException
      * @throws Exception\StreamNotFoundException
      * @throws Exception\UnauthorizedException
      */
-    private function ensureStatusCodeIsGood($stream_url)
+    private function ensureStatusCodeIsGood($streamUrl)
     {
         $code = $this->lastResponse->getStatusCode();
 
         if (array_key_exists($code, $this->badCodeHandlers)) {
-            $this->badCodeHandlers[$code]($stream_url);
+            $this->badCodeHandlers[$code]($streamUrl);
         }
     }
 
     private function initBadCodeHandlers()
     {
         $this->badCodeHandlers = [
-            ResponseCode::HTTP_NOT_FOUND => function ($stream_url) {
+            ResponseCode::HTTP_NOT_FOUND => function ($streamUrl) {
                     throw new StreamNotFoundException(
                         sprintf(
                             'No stream found at %s',
-                            $stream_url
+                            $streamUrl
                         )
                     );
                 },
 
-            ResponseCode::HTTP_GONE => function ($stream_url) {
+            ResponseCode::HTTP_GONE => function ($streamUrl) {
                     throw new StreamDeletedException(
                         sprintf(
                             'Stream at %s has been permanently deleted',
-                            $stream_url
+                            $streamUrl
                         )
                     );
                 },
 
-            ResponseCode::HTTP_UNAUTHORIZED => function ($stream_url) {
+            ResponseCode::HTTP_UNAUTHORIZED => function ($streamUrl) {
                     throw new UnauthorizedException(
                         sprintf(
                             'Tried to open stream %s got 401',
-                            $stream_url
+                            $streamUrl
                         )
                     );
                 }

--- a/src/EventStore/EventStoreInterface.php
+++ b/src/EventStore/EventStoreInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventStore;
 
 use EventStore\StreamFeed\StreamFeed;
@@ -16,11 +17,11 @@ interface EventStoreInterface
     /**
      * Navigate stream feed through link relations
      *
-     * @param  StreamFeed      $stream_feed The stream feed to navigate through
-     * @param  LinkRelation    $relation    The "direction" expressed as link relation
+     * @param  StreamFeed      $streamFeed The stream feed to navigate through
+     * @param  LinkRelation    $relation   The "direction" expressed as link relation
      * @return null|StreamFeed
      */
-    public function navigateStreamFeed(StreamFeed $stream_feed, LinkRelation $relation);
+    public function navigateStreamFeed(StreamFeed $streamFeed, LinkRelation $relation);
 
     /**
      * Get the response from the last HTTP call to the EventStore API
@@ -32,35 +33,35 @@ interface EventStoreInterface
     /**
      * Write one or more events to a stream
      *
-     * @param  string                                  $stream_name     The stream name
+     * @param  string                                  $streamName      The stream name
      * @param  WritableToStream                        $events          Single event or a collection of events
      * @param  int                                     $expectedVersion The expected version of the stream
      * @throws Exception\WrongExpectedVersionException
      */
-    public function writeToStream($stream_name, WritableToStream $events, $expectedVersion = ExpectedVersion::ANY);
+    public function writeToStream($streamName, WritableToStream $events, $expectedVersion = ExpectedVersion::ANY);
 
     /**
      * Read a single event
      *
-     * @param  string $event_url The url of the event
+     * @param  string $eventUrl The url of the event
      * @return Event
      */
-    public function readEvent($event_url);
+    public function readEvent($eventUrl);
 
     /**
      * Delete a stream
      *
-     * @param string         $stream_name Name of the stream
-     * @param StreamDeletion $mode        Deletion mode (soft or hard)
+     * @param string         $streamName Name of the stream
+     * @param StreamDeletion $mode       Deletion mode (soft or hard)
      */
-    public function deleteStream($stream_name, StreamDeletion $mode);
+    public function deleteStream($streamName, StreamDeletion $mode);
 
     /**
      * Open a stream feed for read and navigation
      *
-     * @param  string         $stream_name The stream name
-     * @param  EntryEmbedMode $embed_mode  The event entries embed mode (none, rich or body)
+     * @param  string         $streamName The stream name
+     * @param  EntryEmbedMode $embedMode  The event entries embed mode (none, rich or body)
      * @return StreamFeed
      */
-    public function openStreamFeed($stream_name, EntryEmbedMode $embed_mode = null);
+    public function openStreamFeed($streamName, EntryEmbedMode $embedMode = null);
 }

--- a/src/EventStore/Exception/StreamDeletedException.php
+++ b/src/EventStore/Exception/StreamDeletedException.php
@@ -1,6 +1,11 @@
 <?php
+
 namespace EventStore\Exception;
 
+/**
+ * Class StreamDeletedException
+ * @package EventStore\Exception
+ */
 class StreamDeletedException extends \Exception
 {
 }

--- a/src/EventStore/Exception/StreamNotFoundException.php
+++ b/src/EventStore/Exception/StreamNotFoundException.php
@@ -1,6 +1,11 @@
 <?php
+
 namespace EventStore\Exception;
 
+/**
+ * Class StreamNotFoundException
+ * @package EventStore\Exception
+ */
 class StreamNotFoundException extends \Exception
 {
 }

--- a/src/EventStore/Http/ResponseCode.php
+++ b/src/EventStore/Http/ResponseCode.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventStore\Http;
 
 /**

--- a/src/EventStore/StreamFeed/Event.php
+++ b/src/EventStore/StreamFeed/Event.php
@@ -15,7 +15,6 @@ class Event
 
     /**
      * @param array $data
-     * @param int   $version
      */
     public function __construct(array $data)
     {

--- a/src/EventStore/StreamFeed/StreamFeed.php
+++ b/src/EventStore/StreamFeed/StreamFeed.php
@@ -21,17 +21,17 @@ final class StreamFeed
     private $entryEmbedMode;
 
     /**
-     * @param array          $json_feed
-     * @param EntryEmbedMode $embed_mode
+     * @param array          $jsonFeed
+     * @param EntryEmbedMode $embedMode
      */
-    public function __construct(array $json_feed, EntryEmbedMode $embed_mode = null)
+    public function __construct(array $jsonFeed, EntryEmbedMode $embedMode = null)
     {
-        if ($embed_mode === null) {
-            $embed_mode = EntryEmbedMode::NONE();
+        if ($embedMode === null) {
+            $embedMode = EntryEmbedMode::NONE();
         }
 
-        $this->entryEmbedMode = $embed_mode;
-        $this->json           = $json_feed;
+        $this->entryEmbedMode = $embedMode;
+        $this->json           = $jsonFeed;
     }
 
     /**

--- a/src/EventStore/WritableEventCollection.php
+++ b/src/EventStore/WritableEventCollection.php
@@ -29,7 +29,7 @@ final class WritableEventCollection implements WritableToStream
      */
     public function toStreamData()
     {
-        return array_map(function ($event) {
+        return array_map(function (WritableEvent $event) {
             return $event->toStreamData();
         }, $this->events);
     }

--- a/tests/EventStore/Tests/EventStoreTest.php
+++ b/tests/EventStore/Tests/EventStoreTest.php
@@ -21,7 +21,9 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
         $this->es = new EventStore('http://127.0.0.1:2113');
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function client_successfully_connects_to_event_store()
     {
         $this->assertEquals('200', $this->es->getLastResponse()->getStatusCode());
@@ -39,7 +41,7 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException EventStore\Exception\WrongExpectedVersionException
+     * @expectedException \EventStore\Exception\WrongExpectedVersionException
      */
     public function wrong_expected_version_should_throw_exception()
     {
@@ -105,7 +107,9 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
         new EventStore('http://127.0.0.1:12345/');
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function event_data_is_embedded_with_body_mode()
     {
         $streamName = $this->prepareTestStream();
@@ -116,7 +120,9 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], json_decode($json['entries'][0]['data'], true));
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function event_stream_feed_head_returns_next_link()
     {
         $streamName = $this->prepareTestStream(40);
@@ -128,7 +134,9 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(20, $next->getJson()['entries']);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function event_stream_feed_returns_entries()
     {
         $streamName = $this->prepareTestStream(40);
@@ -139,7 +147,9 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
         $this->assertContainsOnlyInstancesOf('EventStore\StreamFeed\Entry', $entries);
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function get_single_event_from_event_stream()
     {
         $streamName  = $this->prepareTestStream(1);
@@ -155,7 +165,9 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], $event->getData());
     }
 
-    /** @test */
+    /**
+     * @test
+     */
     public function navigate_stream_using_missing_link_returns_null()
     {
         $streamName = $this->prepareTestStream(1);
@@ -168,7 +180,7 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException EventStore\Exception\StreamNotFoundException
+     * @expectedException \EventStore\Exception\StreamNotFoundException
      */
     public function unexistent_stream_should_throw_not_found_exception()
     {
@@ -177,7 +189,7 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException EventStore\Exception\StreamDeletedException
+     * @expectedException \EventStore\Exception\StreamDeletedException
      */
     public function deleted_stream_should_throw_an_exception()
     {
@@ -189,7 +201,7 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException EventStore\Exception\UnauthorizedException
+     * @expectedException \EventStore\Exception\UnauthorizedException
      * @expectedExceptionMessage Tried to open stream http://127.0.0.1:2113/streams/$et-Baz got 401
      */
     public function unauthorized_streams_throw_unauthorized_exception()
@@ -199,7 +211,7 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException EventStore\Exception\StreamDeletedException
+     * @expectedException \EventStore\Exception\StreamDeletedException
      */
     public function fetching_event_of_a_deleted_stream_throws_an_exception()
     {
@@ -214,7 +226,7 @@ class EventStoreTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param  int    $length
+     * @param  integer $length
      * @return string
      */
     private function prepareTestStream($length = 1)

--- a/tests/EventStore/Tests/StreamFeed/EntryTest.php
+++ b/tests/EventStore/Tests/StreamFeed/EntryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EventStore\Tests\StreamFeed;
 
 use EventStore\StreamFeed\Entry;

--- a/tests/EventStore/Tests/StreamFeed/StreamFeedTest.php
+++ b/tests/EventStore/Tests/StreamFeed/StreamFeedTest.php
@@ -1,15 +1,22 @@
 <?php
+
 namespace EventStore\Tests\StreamFeed;
 
 use EventStore\StreamFeed\EntryEmbedMode;
 use EventStore\StreamFeed\StreamFeed;
 use EventStore\StreamFeed\LinkRelation;
 
+/**
+ * Class StreamFeedTest
+ * @package EventStore\Tests\StreamFeed
+ */
 class StreamFeedTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @test
      * @dataProvider modeProvider
+     * @param EntryEmbedMode $mode
+     * @param EntryEmbedMode $expected
      */
     public function event_embed_mode_is_returned_properly(EntryEmbedMode $mode = null, EntryEmbedMode $expected)
     {
@@ -34,6 +41,7 @@ class StreamFeedTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider relationProvider
      * @test
+     * @param LinkRelation $relation
      */
     public function get_link_url_returns_proper_url(LinkRelation $relation)
     {

--- a/tests/EventStore/Tests/WritableEventCollectionTest.php
+++ b/tests/EventStore/Tests/WritableEventCollectionTest.php
@@ -36,7 +36,7 @@ class WritableEventCollectionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
-     * @expectedException EventStore\Exception\InvalidWritableEventObjectException
+     * @expectedException \EventStore\Exception\InvalidWritableEventObjectException
      */
     public function invalid_collection_throws_exception()
     {

--- a/tests/EventStore/Tests/WritableEventTest.php
+++ b/tests/EventStore/Tests/WritableEventTest.php
@@ -5,9 +5,15 @@ namespace EventStore\Tests;
 use EventStore\WritableEvent;
 use ValueObjects\Identity\UUID;
 
+/**
+ * Class WritableEventTest
+ * @package EventStore\Tests
+ */
 class WritableEventTest extends \PHPUnit_Framework_TestCase
 {
-    /** @test */
+    /**
+     * @test
+     */
     public function event_is_converted_to_stream_data()
     {
         $uuid  = new UUID();
@@ -20,5 +26,4 @@ class WritableEventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($streamData, $event->toStreamData());
     }
-
 }


### PR DESCRIPTION
As discussed in PR 18:

* Newline after opening php tag and namespace
* lowerCamelCase for all variable names (including function args)

Additionally I generated PHPDoc comments for all classes.