### PR TITLE
Adds guzzle as a composer require dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,11 @@
     "require": {
         "php": ">=5.5.0",
         "guzzlehttp/psr7": "~1.2",
+        "guzzlehttp/guzzle": "~6.0",
         "ramsey/uuid": "~2.8",
         "marc-mabe/php-enum": "~2.1"
     },
     "require-dev": {
-        "guzzlehttp/guzzle": "~6.0",
         "phpunit/phpunit": "~4.0",
         "kevinrob/guzzle-cache-middleware": "^0.7.1",
         "doctrine/cache": "~1.4"


### PR DESCRIPTION
GuzzleHttpCient is used as the default http client, if none is passed during construction of the EventStore.

Thus the dependency must always be there.